### PR TITLE
samifying path when comparing include & exclude patterns

### DIFF
--- a/org/cfstatic/util/Base.cfc
+++ b/org/cfstatic/util/Base.cfc
@@ -311,8 +311,8 @@
 		<cfargument name="filePath"       type="string" required="true" />
 		<cfargument name="includePattern" type="string" required="true" />
 		<cfargument name="excludePattern" type="string" required="true" />
-
 		<cfscript>
+			filepath = $samifyUnixAndWindowsPaths(filepath);
 			if ( Len(Trim(arguments.includePattern)) AND NOT ReFindNoCase(arguments.includePattern, arguments.filePath) ) {
 				return false;
 			}


### PR DESCRIPTION
little tweak to make sure paths are the same on win & linux when comparing them to include and exclude patterns.  This ensures there are no backslashes in the path which makes the regex much easier
