### PR TITLE
Adding the ability to configure what scope compilers are stored.

### DIFF
--- a/org/cfstatic/CfStatic.cfc
+++ b/org/cfstatic/CfStatic.cfc
@@ -309,7 +309,7 @@
 		<cfscript>
 			// put javaloader instances in server scope due to memory leak issues
 			if(arguments.compilerScope eq "application"){
-				if( not StructKeyExists(server, '_cfstaticJavaloaders') ){
+				if( not StructKeyExists(application, '_cfstaticJavaloaders') ){
 					application['_cfstaticJavaloaders'] = _loadJavaLoaders();
 				}
 
@@ -324,7 +324,6 @@
 				_setYuiCompressor ( CreateObject('component','org.cfstatic.util.YuiCompressor' ).init( server['_cfstaticJavaloaders'].yui  ) );
 				_setLessCompiler  ( CreateObject('component','org.cfstatic.util.LessCompiler'  ).init( server['_cfstaticJavaloaders'].less ) );
 				_setCssImageParser( CreateObject('component','org.cfstatic.util.CssImageParser').init( _getCssUrl(), $listAppend(_getRootDirectory(), _getCssDirectory(), '/' ) ) );
-
 			}
 		</cfscript>
 	</cffunction>
@@ -334,7 +333,7 @@
 			var jarsForYui		  = ArrayNew(1);
 			var jarsForLess		  = ArrayNew(1);
 			var cfstaticJavaloaders   = StructNew();
-
+ 
 			jarsForYui[1]  = ExpandPath('/org/cfstatic/lib/yuiCompressor/yuicompressor-2.4.6.jar');
 			jarsForYui[2]  = ExpandPath('/org/cfstatic/lib/cfstatic.jar');
 			jarsForLess[1] = ExpandPath('/org/cfstatic/lib/less/lesscss-engine-1.3.0.jar');
@@ -342,7 +341,7 @@
 			cfstaticJavaloaders.yui  = CreateObject('component','org.cfstatic.lib.javaloader.JavaLoader').init( jarsForYui  );
 			cfstaticJavaloaders.less = CreateObject('component','org.cfstatic.lib.javaloader.JavaLoader').init( jarsForLess );
 			
-			return cfstaticJavaloaders;
+		 	return cfstaticJavaloaders;
 		</cfscript>
 	</cffunction>
 


### PR DESCRIPTION
We were running into issue with Mura in CF sand boxes.  This adds a compilerScope init argument that can either be server or application.
