### PR TITLE
Renamed variables named final for CF 2018 reserved word compatibility.

### DIFF
--- a/org/cfstatic/core/StaticFile.cfc
+++ b/org/cfstatic/core/StaticFile.cfc
@@ -49,7 +49,7 @@
 		<cfargument name="includeConditionals" type="boolean" required="false" default="true"  />
 
 		<cfscript>
-			var final        = ArrayNew(1);
+			var finalArray        = ArrayNew(1);
 			var added        = StructNew();
 			var deep         = "";
 			var conditionals = "";
@@ -61,26 +61,26 @@
 					deep = _dependencies[i].getDependencies( true );
 					for( n=1; n LTE ArrayLen( deep ); n++ ){
 						if ( not StructKeyExists( added, deep[n].getPath() ) ) {
-							ArrayAppend( final, deep[n] );
+							ArrayAppend( finalArray, deep[n] );
 							added[ deep[n].getPath() ] = true;
 						}
 					}
 				}
 				if ( not StructKeyExists( added, _dependencies[i].getPath() ) ) {
-					ArrayAppend( final, _dependencies[i] );
+					ArrayAppend( finalArray, _dependencies[i] );
 					added[ _dependencies[i].getPath() ] = true;
 				}
 			}
 			if ( not includeConditionals ) {
 				conditionals = ArrayToList( _getConditionalDependencies() );
-				for( i=ArrayLen( final ); i GT 0 ; i-- ){
-					if ( ListFindNoCase( conditionals, final[i].getPath() ) ) {
-						ArrayDeleteAt( final, i );
+				for( i=ArrayLen( finalArray ); i GT 0 ; i-- ){
+					if ( ListFindNoCase( conditionals, finalArray[i].getPath() ) ) {
+						ArrayDeleteAt( finalArray, i );
 					}
 				}
 			}
 
-			return _bubbleSort( final );
+			return _bubbleSort( finalArray );
 		</cfscript>
 	</cffunction>
 

--- a/org/cfstatic/util/Base.cfc
+++ b/org/cfstatic/util/Base.cfc
@@ -101,23 +101,23 @@
 		<cfargument name="text"  type="string" required="true" />
 
 		<cfscript>
-			var final  = StructNew();
+			var finalStruct  = StructNew();
 			var pos    = 1;
 			var result = ReFindNoCase( regex, text, pos, true );
 			var i      = 0;
 
 			while( ArrayLen( result.pos ) GT 1 ) {
 				for( i=2; i LTE ArrayLen( result.pos ); i++ ){
-					if ( not StructKeyExists( final, '$#i-1#' ) ) {
-						final[ '$#i-1#' ] = ArrayNew(1);
+					if ( not StructKeyExists( finalStruct, '$#i-1#' ) ) {
+						finalStruct[ '$#i-1#' ] = ArrayNew(1);
 					}
-					ArrayAppend( final[ '$#i-1#' ], Mid( text, result.pos[i], result.len[i] ) );
+					ArrayAppend( finalStruct[ '$#i-1#' ], Mid( text, result.pos[i], result.len[i] ) );
 				}
 				pos = result.pos[2] + 1;
 				result	= ReFindNoCase( regex, text, pos, true );
 			};
 
-			return final;
+			return finalStruct;
 		</cfscript>
 	</cffunction>
 


### PR DESCRIPTION
ACF added "final" as a reserved word causing cfstatic to fail to load.