### PR TITLE
Add async & defer for script tags

### DIFF
--- a/org/cfstatic/core/Package.cfc
+++ b/org/cfstatic/core/Package.cfc
@@ -97,6 +97,8 @@
 			var media            = "";
 			var ie               = "";
 			var shouldBeRendered = "";
+			var async			 = "";
+			var defer			 = "";
 
 			switch( minification ){
 				case 'none': case 'file':
@@ -119,7 +121,10 @@
 						media = getCssMedia();
 						return $renderCssInclude( src, media, ie );
 					} else {
-						return $renderJsInclude( src, ie );
+						async  = getJSAsync();
+						defer  = getJSDefer();
+
+						return $renderJsInclude( src, ie, async, defer );
 					}
 					break;
 			}
@@ -160,6 +165,44 @@
 			}
 
 			return ieRestriction;
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="getJSAsync" access="public" returntype="string" output="false" hint="I get the target async property of the JS files for the entire package. All static files within a single package should have the same async property (when minifiying all together), an exception will be thrown otherwise..">
+		<cfscript>
+			var files         = getOrdered();
+			var async         = "";
+			var i             = 0;
+
+			if ( ArrayLen( files ) ) {
+				async = getStaticFile( files[1] ).getProperty('async', 'false', 'string');
+				for( i=2; i LTE ArrayLen(files); i++ ){
+					if ( async NEQ getStaticFile( files[i] ).getProperty('async', 'false', 'string') ) {
+						$throw( type="cfstatic.Package.badConfig", message="There was an error compiling the package, '#_getPackageName()#', not all files define the same async property." );
+					}
+				}
+			}
+
+			return async;
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="getJSDefer" access="public" returntype="string" output="false" hint="I get the target defer property of the JS files for the entire package. All static files within a single package should have the same defer property (when minifiying all together), an exception will be thrown otherwise..">
+		<cfscript>
+			var files         = getOrdered();
+			var defer         = "";
+			var i             = 0;
+
+			if ( ArrayLen( files ) ) {
+				defer = getStaticFile( files[1] ).getProperty('defer', 'false', 'string');
+				for( i=2; i LTE ArrayLen(files); i++ ){
+					if ( defer NEQ getStaticFile( files[i] ).getProperty('defer', 'false', 'string') ) {
+						$throw( type="cfstatic.Package.badConfig", message="There was an error compiling the package, '#_getPackageName()#', not all files define the same defer property." );
+					}
+				}
+			}
+
+			return defer;
 		</cfscript>
 	</cffunction>
 

--- a/org/cfstatic/core/PackageCollection.cfc
+++ b/org/cfstatic/core/PackageCollection.cfc
@@ -78,6 +78,8 @@
 			var media            = "";
 			var ie               = "";
 			var shouldBeRendered = "";
+			var async            = "";
+			var defer			 = "";
 
 			switch( minification ){
 				case 'none': case 'file': case 'package':
@@ -109,7 +111,11 @@
 						media = _getCssMedia();
 						str.append( $renderCssInclude( src, media, ie ) );
 					} else {
-						str.append( $renderJsInclude( src, ie ) );
+
+						async = _getJSAsync();
+						defer = _getJSDefer();
+
+						str.append( $renderJsInclude( src, ie, async, defer ) );
 					}
 					break;
 			}
@@ -404,6 +410,44 @@
 			}
 
 			return media;
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="_getJSAsync" access="public" returntype="string" output="false" hint="I get the target async property of the JS files for the entire package. All static files within a single package should have the same async property (when minifiying all together), an exception will be thrown otherwise..">
+		<cfscript>
+			var packages = getOrdered();
+			var async    = "";
+			var i        = 0;
+
+			if ( ArrayLen( packages ) ) {
+				async = getPackage( packages[1] ).getJSAsync();
+				for( i=2; i LTE ArrayLen( packages ); i++ ) {
+					if ( async NEQ getPackage( packages[i] ).getJSAsync() ) {
+						$throw( type="cfstatic.PackageCollection.badConfig", message="There was an error compiling the #_getFileType()# min file, not all files define the same Async property." );
+					}
+				}
+			}
+
+			return async;
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="_getJSDefer" access="public" returntype="string" output="false" hint="I get the target defer property of the JS files for the entire package. All static files within a single package should have the same defer property (when minifiying all together), an exception will be thrown otherwise..">
+		<cfscript>
+			var packages = getOrdered();
+			var defer    = "";
+			var i        = 0;
+
+			if ( ArrayLen( packages ) ) {
+				defer = getPackage( packages[1] ).getJSDefer();
+				for( i=2; i LTE ArrayLen( packages ); i++ ) {
+					if ( defer NEQ getPackage( packages[i] ).getJSDefer() ) {
+						$throw( type="cfstatic.PackageCollection.badConfig", message="There was an error compiling the #_getFileType()# min file, not all files define the same Defer property." );
+					}
+				}
+			}
+
+			return defer;
 		</cfscript>
 	</cffunction>
 

--- a/org/cfstatic/core/StaticFile.cfc
+++ b/org/cfstatic/core/StaticFile.cfc
@@ -127,13 +127,16 @@
 		<cfscript>
 			var media = getProperty( 'media', 'all', 'string' );
 			var ie    = getProperty( 'IE', '', 'string' );
+			var async = getProperty( 'async', 'false', 'string' );
+			var defer = getProperty( 'defer', 'false', 'string' );
+
 			var src   = iif( minified, DE( _getMinifiedUrl() ), DE( _getUrl() ) );
 
 			if ( _getFileType() EQ 'css' ) {
 				return $renderCssInclude( src, media, ie );
 
 			} else {
-				return $renderJsInclude( src, ie );
+				return $renderJsInclude( src, ie, async, defer );
 			}
 		</cfscript>
 	</cffunction>

--- a/org/cfstatic/util/Base.cfc
+++ b/org/cfstatic/util/Base.cfc
@@ -178,8 +178,10 @@
 	<cffunction name="$renderJsInclude" access="private" returntype="string" output="false" hint="I return the html nevessary to include the given javascript file">
 		<cfargument name="src"           type="string" required="true"                  />
 		<cfargument name="ieConditional" type="string" required="false" default=""      />
+		<cfargument name="async" 		 type="string" required="false" default="false" />
+		<cfargument name="defer" 		 type="string" required="false" default="false" />
 
-		<cfreturn $renderIeConditional( '<script type="text/javascript" src="#src#"></script>', ieConditional ) & $newline() />
+		<cfreturn $renderIeConditional( '<script type="text/javascript" src="#src#" #arguments.async EQ "true" ? "async" : ""# #arguments.defer EQ "true" ? "defer" : ""# ></script>', ieConditional ) & $newline() />
 	</cffunction>
 
 	<cffunction name="$extractUrlFromRenderedInclude" access="private" returntype="string" output="false">


### PR DESCRIPTION
annotations @async and @defer can control whether to add these attributes to script tags